### PR TITLE
Fix: 重複するnvim-notifyの設定を整理

### DIFF
--- a/lua/plugins/nerv.lua
+++ b/lua/plugins/nerv.lua
@@ -5,7 +5,8 @@ return {
     priority = 1000,
     opts = {},
   },
-  -- nvim-notify
+  -- nvim-notify - メインの通知プラグイン設定
+  -- このプラグインはnoice.nvimの依存関係としても使用されますが、設定はここで一元管理します
   {
     "rcarriga/nvim-notify",
     lazy = false,

--- a/lua/plugins/noice.lua
+++ b/lua/plugins/noice.lua
@@ -11,6 +11,7 @@ return {
     -- OPTIONAL:
     --   `nvim-notify` is only needed, if you want to use the notification view.
     --   If not available, we use `mini` as the fallback
+    -- 注意: nvim-notifyの設定は lua/plugins/nerv.lua で一元管理されています
     "rcarriga/nvim-notify",
   },
   config = function()
@@ -280,7 +281,7 @@ return {
       },
     })
 
-    -- nvim-notifyの設定を上書きしないように、NERV-themeの設定後に実行
+    -- NERV風のハイライトグループを設定（nvim-notifyの設定は nerv.lua で行う）
     vim.defer_fn(function()
       -- noice.nvimのハイライトグループをNERV風に設定
       vim.api.nvim_set_hl(0, "NoiceCmdlinePopupBorder", { fg = nerv_colors.nerv_orange, bg = nerv_colors.black })
@@ -288,14 +289,7 @@ return {
       vim.api.nvim_set_hl(0, "NoiceCmdlineIcon", { fg = nerv_colors.nerv_green, bg = nerv_colors.black })
       vim.api.nvim_set_hl(0, "NoiceConfirmBorder", { fg = nerv_colors.nerv_blue, bg = nerv_colors.black })
       
-      -- 通知の文字色を明るく設定して見やすくする
-      vim.api.nvim_set_hl(0, "NotifyERRORBody", { fg = nerv_colors.fg, bg = nerv_colors.black })
-      vim.api.nvim_set_hl(0, "NotifyWARNBody", { fg = nerv_colors.fg, bg = nerv_colors.black })
-      vim.api.nvim_set_hl(0, "NotifyINFOBody", { fg = nerv_colors.fg, bg = nerv_colors.black })
-      vim.api.nvim_set_hl(0, "NotifyDEBUGBody", { fg = nerv_colors.fg, bg = nerv_colors.black })
-      vim.api.nvim_set_hl(0, "NotifyTRACEBody", { fg = nerv_colors.fg, bg = nerv_colors.black })
-      
-      -- Noiceの通知本文のハイライトも設定
+      -- Noiceの通知本文のハイライトを設定
       vim.api.nvim_set_hl(0, "NoicePopupmenuMatch", { fg = nerv_colors.nerv_orange, bold = true })
       vim.api.nvim_set_hl(0, "NoicePopupmenuSelected", { bg = nerv_colors.bg, fg = nerv_colors.nerv_yellow, bold = true })
       vim.api.nvim_set_hl(0, "NoiceLspProgressTitle", { fg = nerv_colors.nerv_blue, bg = nerv_colors.black })


### PR DESCRIPTION
## 問題点

`rcarriga/nvim-notify`の設定が2つの場所で行われていました：

1. `lua/plugins/nerv.lua` - プラグインのメイン設定
2. `lua/plugins/noice.lua` - 依存関係として、かつハイライト設定の重複

## 修正内容

- `noice.lua`から重複するnvim-notifyのハイライト設定を削除
- 両方のファイルに明確なコメントを追加して、設定が`nerv.lua`で一元管理されていることを示す
- コードの可読性と保守性を向上

この変更により、設定の競合を防ぎつつ、NERV風のテーマと機能はすべて維持されています。